### PR TITLE
Updates to bench-fio.sh

### DIFF
--- a/benchmark_script/bench-fio.sh
+++ b/benchmark_script/bench-fio.sh
@@ -40,11 +40,11 @@ then
 	exit 1
 fi
 
-for x in randread randwrite
+for RW in randread randwrite
 do
-	for y in 1 2 4 8 16 32
+	for IODEPTH in 1 2 4 8 16 32
 	do
-		for z in 1 2 4 8 16 32
+		for NUMJOBS in 1 2 4 8 16 32
 		do
 			sync
 			echo 3 > /proc/sys/vm/drop_caches
@@ -52,10 +52,10 @@ do
 			echo "=== $FILE ============================================"
 			echo "Running benchmark $x with I/O depth of $y and numjobs $z"
 			cd $OUTPUT
-			export RW=$x
-			export IODEPTH=$y
-			export NUMJOBS=$z
-			$FIO $JOBFILE --output-format=json > $OUTPUT/$x-$y-$z.json
+			export RW
+			export IODEPTH
+			export NUMJOBS
+			$FIO $JOBFILE --output-format=json --output=$OUTPUT/$RW-$IODEPTH-$NUMJOBS.json
 			cd $MYPWD
 		done
 	done

--- a/benchmark_script/bench-fio.sh
+++ b/benchmark_script/bench-fio.sh
@@ -8,6 +8,12 @@ then
 	exit 1
 fi
 
+if [ -z ${FIO+x} ]
+then
+	FIO=fio
+fi
+
+
 export BLOCKSIZE=4k 
 export RUNTIME=60
 export JOBFILE=$1
@@ -16,7 +22,7 @@ export DIRECTORY=$3
 export FILE=$4
 export SIZE=$5
 
-if [ ! $(fio --version | grep -i fio-3) ]
+if [ ! $($FIO --version | grep -i fio-3) ]
 then
 	echo "Fio version 3+ required because fio-plot expects nanosecond precision"
 	exit 1
@@ -49,7 +55,7 @@ do
 			export RW=$x
 			export IODEPTH=$y
 			export NUMJOBS=$z
-			fio $JOBFILE --output-format=json > $OUTPUT/$x-$y-$z.json
+			$FIO $JOBFILE --output-format=json > $OUTPUT/$x-$y-$z.json
 			cd $MYPWD
 		done
 	done

--- a/benchmark_script/bench-fio.sh
+++ b/benchmark_script/bench-fio.sh
@@ -50,7 +50,7 @@ do
 			echo 3 > /proc/sys/vm/drop_caches
 			MYPWD=`pwd`
 			echo "=== $FILE ============================================"
-			echo "Running benchmark $x with I/O depth of $y and numjobs $z"
+			echo "Running benchmark $RW with I/O depth of $IODEPTH and numjobs $NUMJOBS"
 			cd $OUTPUT
 			export RW
 			export IODEPTH

--- a/benchmark_script/bench-fio.sh
+++ b/benchmark_script/bench-fio.sh
@@ -48,15 +48,12 @@ do
 		do
 			sync
 			echo 3 > /proc/sys/vm/drop_caches
-			MYPWD=`pwd`
 			echo "=== $FILE ============================================"
 			echo "Running benchmark $RW with I/O depth of $IODEPTH and numjobs $NUMJOBS"
-			cd $OUTPUT
 			export RW
 			export IODEPTH
 			export NUMJOBS
 			$FIO $JOBFILE --output-format=json --output=$OUTPUT/$RW-$IODEPTH-$NUMJOBS.json
-			cd $MYPWD
 		done
 	done
 done

--- a/benchmark_script/bench-fio.sh
+++ b/benchmark_script/bench-fio.sh
@@ -1,5 +1,13 @@
 #!/bin/bash
 
+set -eu
+
+if [ $# -ne 5 ]
+then
+	echo "Usage: $0 <JOBFILE> <OUTPUT> <DIRECTORY> <FILE> <SIZE>"
+	exit 1
+fi
+
 export BLOCKSIZE=4k 
 export RUNTIME=60
 export JOBFILE=$1
@@ -41,7 +49,7 @@ do
 			export RW=$x
 			export IODEPTH=$y
 			export NUMJOBS=$z
-			fio $1 --output-format=json > $OUTPUT/$x-$y-$z.json   
+			fio $JOBFILE --output-format=json > $OUTPUT/$x-$y-$z.json
 			cd $MYPWD
 		done
 	done

--- a/benchmark_script/fio-job-template-file.fio
+++ b/benchmark_script/fio-job-template-file.fio
@@ -12,8 +12,8 @@ refill_buffers=1
 runtime=${RUNTIME}
 numjobs=${NUMJOBS}
 group_reporting=1
-write_bw_log=${RW}-iodepth-${IODEPTH}-numjobs-${NUMJOBS}
-write_lat_log=${RW}-iodepth-${IODEPTH}-numjobs-${NUMJOBS}
-write_iops_log=${RW}-iodepth-${IODEPTH}-numjobs-${NUMJOBS}
+write_bw_log=${OUTPUT}/${RW}-iodepth-${IODEPTH}-numjobs-${NUMJOBS}
+write_lat_log=${OUTPUT}/${RW}-iodepth-${IODEPTH}-numjobs-${NUMJOBS}
+write_iops_log=${OUTPUT}/${RW}-iodepth-${IODEPTH}-numjobs-${NUMJOBS}
 log_avg_msec=250
 


### PR DESCRIPTION
Hi,

This is just a few cosmetic changes, this should be backward compatible.

- check arguments
- variable FIO to use another executable
- rename a few variables

Tell me if it's fine for you.

Also, when trying to use the python script, `-T` seems mandatory, could we make this argument `required=True`?