### PR TITLE
Use selected metric in saved file name

### DIFF
--- a/fio_plot/fiolib/bar3d.py
+++ b/fio_plot/fiolib/bar3d.py
@@ -150,6 +150,6 @@ def plot_3d(settings, dataset):
 
     plt.tight_layout()
     now = datetime.now().strftime('%Y-%m-%d_%H%M%S')
-    plt.savefig('3d-iops-jobs' +
+    plt.savefig('3d-' + str(metric) + '-jobs' +
                 str(settings['rw']) + "-" + str(now) + '.png')
     plt.close('all')


### PR DESCRIPTION
The image is statically named with `3d-iops-jobs` at the beginning of the file name no matter what was selected as `metric`.