### PR TITLE
Filter JSON files based on internal keys

### DIFF
--- a/fio_plot/fiolib/jsonimport.py
+++ b/fio_plot/fiolib/jsonimport.py
@@ -1,45 +1,48 @@
 import os
 import sys
 import json
+import logging
 import pprint
+
+logger = logging.getLogger(__name__)
 
 
 def filter_json_files(settings, filename):
-    """Filter the json files to only those we need.
-    My ambition is to learn to program and do this right one day.
-    """
-    basename = os.path.basename(filename)
-    splitone = str.split(basename, ".")
-    split = str.split(splitone[0], "-")
-    iodepth = int(split[1])
-    numjobs = int(split[2])
-
-    if iodepth in settings["iodepth"] and numjobs in settings["numjobs"]:
-        return filename
+    """A bit of a slow process, but guarantees that we get legal
+    json files regardless of their names"""
+    with open(filename, 'r') as candidate_file:
+        try:
+            candidate_json = json.load(candidate_file)
+            if candidate_json["fio version"]:
+                if candidate_json["jobs"][0]["job options"]["rw"] == settings["rw"]:
+                    return filename
+            else:
+                logger.debug(f"{filename} does not appear to be a valid fio json output file, skipping")
+        except Exception as e:
+            logger.warning(e)
 
 
 def list_json_files(settings, fail=True):
     """List all JSON files that maches the command line settings."""
-    json_files = []
+    input_directories = []
     for directory in settings["input_directory"]:
         absolute_dir = os.path.abspath(directory)
-        dict_structure = {"directory": absolute_dir, "files": []}
-        files = os.listdir(absolute_dir)
-        for item in files:
-            if item.endswith(".json"):
-                if item.startswith(settings["rw"]):
-                    dict_structure["files"].append(os.path.join(absolute_dir, item))
-        json_files.append(dict_structure)
+        input_dir_struct = {"directory": absolute_dir, "files": []}
+        input_dir_files = os.listdir(absolute_dir)
+        for file in input_dir_files:
+            if file.endswith(".json"):
+                input_dir_struct["files"].append(os.path.join(absolute_dir, file))
+        input_directories.append(input_dir_struct)
 
-    for item in json_files:
+    for directory in input_directories:
         file_list = []
-        for f in item["files"]:
-            result = filter_json_files(settings, f)
+        for file in directory["files"]:
+            result = filter_json_files(settings, file)
             if result:
                 file_list.append(result)
 
-        item["files"] = sorted(file_list)
-        if not item["files"] and fail:
+        directory["files"] = sorted(file_list)
+        if not directory["files"] and fail:
             print(
                 f"\nCould not find any (matching) JSON files in the specified directory {str(absolute_dir)}\n"
             )
@@ -50,7 +53,7 @@ def list_json_files(settings, fail=True):
             sys.exit(1)
 
     # pprint.pprint(json_files)
-    return json_files
+    return input_directories
 
 
 def import_json_data(filename):
@@ -75,6 +78,7 @@ def import_json_dataset(settings, dataset):
             item["rawdata"].append(import_json_data(f))
     return dataset
 
+
 def get_nested_value(dictionary, key):
     """This function reads the data from the FIO JSON file based on the supplied
     key (which is often a nested path within the JSON file).
@@ -93,11 +97,13 @@ def check_for_steadystate(dataset, mode):
     else:
         return False
 
+
 def walk_dictionary(dictionary, path):
     result = dictionary
     for item in path:
         result = result[item]
     return result
+
 
 def validate_job_option_key(dataset):
     mykeys = dataset['jobs'][0]['job options'].keys()
@@ -105,6 +111,7 @@ def validate_job_option_key(dataset):
         return True
     else:
         raise KeyError
+
 
 def validate_job_options(dataset, ):
     ## This chain of error handling is beyond ridiculous and disgusting.
@@ -116,12 +123,14 @@ def validate_job_options(dataset, ):
     except KeyError:
         return ['global options']
 
+
 def validate_number_of_jobs(dataset):
     length = len(dataset[0]['rawdata'][0]['jobs'])
     if length > 1:
         print("\n Unfortunately, fio-plot can't deal (yet) with JSON files containing multiple jobs\n")
         print("See also: https://github.com/louwrentius/fio-plot/issues/64")
         sys.exit(1)
+
 
 def get_json_mapping(mode, dataset):
     """This function contains a hard-coded mapping of FIO nested JSON data
@@ -156,7 +165,7 @@ def get_json_mapping(mode, dataset):
         dictionary["ss_settings"] = ["global options"] + ["steadystate"]
         dictionary["ss_data_bw_mean"] = root + ["steadystate"] + ["data"] + ["bw_mean"]
         dictionary["ss_data_iops_mean"] = (
-            root + ["steadystate"] + ["data"] + ["iops_mean"]
+                root + ["steadystate"] + ["data"] + ["iops_mean"]
         )
 
     else:
@@ -215,5 +224,5 @@ def get_flat_json_mapping(settings, dataset):
                 "fio_version": get_nested_value(record, m["fio_version"]),
             }
             item["data"].append(row)
-            #item["rawdata"] = None  # --> enable to throw away the data after parsing.
+            # item["rawdata"] = None  # --> enable to throw away the data after parsing.
     return dataset

--- a/fio_plot/fiolib/jsonimport.py
+++ b/fio_plot/fiolib/jsonimport.py
@@ -14,8 +14,12 @@ def filter_json_files(settings, filename):
         try:
             candidate_json = json.load(candidate_file)
             if candidate_json["fio version"]:
-                if candidate_json["jobs"][0]["job options"]["rw"] == settings["rw"]:
-                    return filename
+                job_options = candidate_json["jobs"][0]["job options"]
+                if job_options["rw"] == settings["rw"]:
+                    iodepth = int(job_options["iodepth"])
+                    numjobs = int(job_options["numjobs"])
+                    if iodepth in settings["iodepth"] and numjobs in settings["numjobs"]:
+                        return filename
             else:
                 logger.debug(f"{filename} does not appear to be a valid fio json output file, skipping")
         except Exception as e:


### PR DESCRIPTION
A very simple solution to the issue opened in #70 , the filtering function that previously used filenames now opens the json file and checks for some basic keys that should be present if the output was created by fio.