### PR TITLE
Arg processing was busting on no output file.

### DIFF
--- a/fio_plot/fiolib/supporting.py
+++ b/fio_plot/fiolib/supporting.py
@@ -405,7 +405,10 @@ def save_png(settings, plt, fig):
     title = title.replace("/", "-")
     plt.tight_layout(rect=[0, 0, 1, 1])
     random = random_char(2)
-    savename = f"{title}_{now}_{random}.png" if len(settings["output_filename"]) == 0 else settings["output_filename"]
+    if settings["output_filename"] is None or  len(settings["output_filename"]) > 0 :
+        savename = f"{title}_{now}_{random}.png"
+    else:
+        savename = settings["output_filename"]
     print(f"\n Saving to file {savename}\n")
     fig.savefig(savename, dpi=settings["dpi"])
     write_png_metadata(savename, settings)


### PR DESCRIPTION
Hey; I found fio-plot to crash if I did not supply an output filename.
```
(fio-plot) [asr@az1-asrrhel8-lab01 fio-work]$ fio-plot -i /var/tmp/fio-work/benchfio/fio-work-dir/4k/ --source "yadda" -T "Allen doing experiment" -l -r randread
Traceback (most recent call last):
  File "/var/tmp/fio-work/fio-plot/bin/fio-plot", line 33, in <module>
    sys.exit(load_entry_point('fio-plot==1.0.21', 'console_scripts', 'fio-plot')())
  File "/var/tmp/fio-work/fio-plot/lib64/python3.9/site-packages/fio_plot/__init__.py", line 45, in main
    routing_dict[graphtype]["function"](settings, data)
  File "/var/tmp/fio-work/fio-plot/lib64/python3.9/site-packages/fio_plot/fiolib/bar2d.py", line 153, in chart_2dbarchart_jsonlogdata
    supporting.save_png(settings, plt, fig)
  File "/var/tmp/fio-work/fio-plot/lib64/python3.9/site-packages/fio_plot/fiolib/supporting.py", line 408, in save_png
    savename = f"{title}_{now}_{random}.png" if len(settings["output_filename"]) == 0 else settings["output_filename"]
TypeError: object of type 'NoneType' has no len()
```

This appears to have fixed it. 