### PR TITLE
Supply plotting library an axis to squeeze.

### DIFF
--- a/fio_plot/fiolib/bar3d.py
+++ b/fio_plot/fiolib/bar3d.py
@@ -137,7 +137,7 @@ def plot_3d(settings, dataset):
     norm = mpl.colors.Normalize(vmin=0, vmax=dz.max())
     sm = plt.cm.ScalarMappable(cmap=cmap, norm=norm)
     sm.set_array([])
-    res = fig.colorbar(sm, fraction=0.046, pad=0.19)
+    res = fig.colorbar(sm, fraction=0.046, pad=0.19, ax=ax1)
     res.ax.set_title(z_axis_label)
 
     # Set tics for x/y axis


### PR DESCRIPTION
Heya.  I found fio-plot to crash.

```
(fio-plot) [asr@az1-asrrhel8-lab01 fio-work]$ fio-plot -i /var/tmp/fio-work/benchfio/fio-work-dir/4k/    --source "yadda"  -T "title here" -L -t iops -r randread -o bar.png
Traceback (most recent call last):
  File "/var/tmp/fio-work/fio-plot/bin/fio-plot", line 33, in <module>
    sys.exit(load_entry_point('fio-plot==1.0.21', 'console_scripts', 'fio-plot')())
  File "/var/tmp/fio-work/fio-plot/lib64/python3.9/site-packages/fio_plot/__init__.py", line 45, in main
    routing_dict[graphtype]["function"](settings, data)
  File "/var/tmp/fio-work/fio-plot/lib64/python3.9/site-packages/fio_plot/fiolib/bar3d.py", line 140, in plot_3d
    res = fig.colorbar(sm, fraction=0.046, pad=0.19)
  File "/var/tmp/fio-work/fio-plot/lib64/python3.9/site-packages/matplotlib/figure.py", line 1256, in colorbar
    raise ValueError(
ValueError: Unable to determine Axes to steal space for Colorbar. Either provide the *cax* argument to use as the Axes for the Colorbar, provide the *ax* argument to steal space from it, or add *mappable* to an Axes.
```

I followed the suggestion and added an ax argument.


