### PR TITLE
fiolib/supporting: Allow for single scale factor

### DIFF
--- a/fio_plot/fiolib/supporting.py
+++ b/fio_plot/fiolib/supporting.py
@@ -72,13 +72,7 @@ def get_largest_scale_factor(scale_factors):
     """Based on multiple dataset, it is determined what the highest scale factor
     is. This assures that the values on the y-axis don't become too large.
     """
-    scalefactor = scale_factors[0]
-    largestscalefactor = [x for x in scale_factors if x["scale"] > scalefactor["scale"]]
-    if not largestscalefactor:
-        largestscalefactor = scalefactor
-    if isinstance(largestscalefactor, list):
-        largestscalefactor = largestscalefactor[0]
-    return largestscalefactor
+    return max([x for x in scale_factors if x], key=lambda x: x["scale"])
 
 
 def scale_yaxis(dataset, scale):


### PR DESCRIPTION
A plot with a single scale factor will fail scale traversal with existing code.

Signed-off-by: Jonathan Derrick <jonathan.derrick@linux.dev>