### PR TITLE
Added scale factors for small values

### DIFF
--- a/fio_plot/fiolib/supporting.py
+++ b/fio_plot/fiolib/supporting.py
@@ -67,6 +67,9 @@ def get_scale_factor_lat(dataset):
         if mean > item["scale"] * 5:
             return item
 
+    # Fallback case when latency is very small 
+    return scale_factors[-1]
+
 
 def get_largest_scale_factor(scale_factors):
     """Based on multiple dataset, it is determined what the highest scale factor
@@ -96,6 +99,9 @@ def get_scale_factor_iops(dataset):
         if mean > item["scale"] * 5:
             return item
 
+    # Fallback case when IOPS is very small 
+    return scale_factors[-1]
+
 
 def get_scale_factor_bw(dataset):
     mean = statistics.mean(dataset)
@@ -108,6 +114,9 @@ def get_scale_factor_bw(dataset):
     for item in scale_factors:
         if mean > item["scale"] * 5:
             return item
+
+    # Fallback case when BW is very small 
+    return scale_factors[-1]
 
 
 def get_scale_factor_bw_ss(dataset):
@@ -122,6 +131,9 @@ def get_scale_factor_bw_ss(dataset):
     for item in scale_factors:
         if mean > item["scale"] * 5:
             return item
+
+    # Fallback case when BW (steady-state) is very small 
+    return scale_factors[-1]
 
 
 def lookupTable(metric):


### PR DESCRIPTION
This commit fixes a bug that caused a runtime error when a metric (latency, IOPS or bandwidth) has a very small value (e.g., this may happen when we try to plot READ results from a benchmark that performed only WRITE operations).