### PR TITLE
Fix bug when ploting with multiple hosts or "All clients".

### DIFF
--- a/fio_plot/fiolib/jsonparsing_support.py
+++ b/fio_plot/fiolib/jsonparsing_support.py
@@ -134,7 +134,7 @@ def merge_job_data_if_hostnames(hosts, directory):
         for host in hosts.keys():
             if len(hosts[host]) > 1 or host == "All clients":
                 #print(host)
-                directory["data"] = merge_job_data_from_hosts(hosts)
+                directory["data"].extend(merge_job_data_from_hosts(hosts))
             else:
                 just_append = True
     else:


### PR DESCRIPTION
Due to this issue, https://github.com/louwrentius/fio-plot/issues/102#issuecomment-1491934498.
I've tested this fix and seems to work properly now.

`fio-plot -i nfsv3_randread_9v1/4k/ -T "TEST NFS CLIENTS" -l -r randread -d 1 8 32 128 --include-hosts "All clients" "172.23.0.5"`

![TEST-NFS-CLIENTS_2023-04-01_021357_As](https://user-images.githubusercontent.com/8962458/229198397-860d1a33-b976-4c32-be12-4193c4927200.png)
