### PR TITLE
Add directory to hostname in line chart legend

### DIFF
--- a/fio_plot/fiolib/graph2dsupporting.py
+++ b/fio_plot/fiolib/graph2dsupporting.py
@@ -23,7 +23,7 @@ def get_json_data(settings):
 
 def create_label(item):
     if item["hostname"]:
-        mydir = item["hostname"]
+        mydir = item["hostname"] + "/" + f"{item['directory']}"
     else:
         mydir = f"{item['directory']}"
     return mydir


### PR DESCRIPTION
Fixes #111.  This should make it possible to distinguish multiple series from the same host (e.g. tests with different block sizes) when they are graphed on the same chart

I'm not sure if this is the best way to go about it but it seems to work:
![CleanShot 2023-04-11 at 13 21 43](https://user-images.githubusercontent.com/49793/231254728-1cee3152-9c99-4bce-ba44-2205c5b9b0b9.png)

It's also possible to use the `--xlabel-parent` and `--xlabel-depth` options to choose which parts of the directory to display after the host name.

There does still seem to be an issue where the subtitle of the graph only displays the first block size.