### PR TITLE
Fix incorrect y-axis scaling 

### DIFF
--- a/fio_plot/fiolib/supporting.py
+++ b/fio_plot/fiolib/supporting.py
@@ -214,7 +214,6 @@ def raw_stddev_to_percent(values, stddev_series):
 
 
 def process_dataset(settings, dataset):
-
     datatypes = []
     new_list = []
     new_structure = {"datatypes": None, "dataset": None}
@@ -258,20 +257,20 @@ def process_dataset(settings, dataset):
                         if x == "bw":
                             scale_factors_bw.append(get_scale_factor_bw(record[rw]["yvalues"]))
                     #print(item["hostname"])
-                    if settings["draw_total"] and len(settings["filter"]) == 2:
-                        readdata = record["read"]["yvalues"]
-                        writedata = record["write"]["yvalues"]
-                        record["total"] = {}
-                        record["total"]["yvalues"] = [x + y for x, y in zip(readdata, writedata)]
-                        record["total"]["xvalues"] = record["read"]["xvalues"] # hack
-                        if item["type"] in ["lat", "clat", "slat"]:
-                            scale_factors_lat.append(get_scale_factor_lat(record["total"]["yvalues"]))
-                        if "bw" in item["type"]:
-                            scale_factors_bw.append(get_scale_factor_bw(record["total"]["yvalues"]))
+            if settings["draw_total"] and len(settings["filter"]) == 2:
+                readdata = record["read"]["yvalues"]
+                writedata = record["write"]["yvalues"]
+                record["total"] = {}
+                record["total"]["yvalues"] = [x + y for x, y in zip(readdata, writedata)]
+                record["total"]["xvalues"] = record["read"]["xvalues"] # hack
+                if item["type"] in ["lat", "clat", "slat"]:
+                    scale_factors_lat.append(get_scale_factor_lat(record["total"]["yvalues"]))
+                if "bw" in item["type"]:
+                    scale_factors_bw.append(get_scale_factor_bw(record["total"]["yvalues"]))
                     #print(item["hostname"])
-                    new_list.append(record)
+            new_list.append(record)
     item.pop("data")
-    
+
     """
     This second loop assures that all data is scaled with the same factor
     """


### PR DESCRIPTION
When plotting read and writes together as a line graph, the y-axis scale is incorrect.
Following commands can be used to reproduce this:

Incorrect:
```
fio-plot -i Foo -T "Bug" -g -t lat -n 1 -d 16 -r randrw --xlabel-parent 0 --filter write read
```

Correct:
```
fio-plot -i Foo -T "Bug" -g -t lat -n 1 -d 16 -r randrw --xlabel-parent 0 --filter write
fio-plot -i Foo -T "Bug" -g -t lat -n 1 -d 16 -r randrw --xlabel-parent 0 --filter read
```

When plotting reads and writes separately, the output is correct. When plotting them together, the y-axis scale is incorrect.
