### PR TITLE
Update setup.py - missing dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ setuptools.setup(
     long_description_content_type="text/markdown",
     url="https://github.com/louwrentius/fio-plot/",
     packages=setuptools.find_packages(),
-    install_requires=["numpy", "matplotlib", "Pillow", "pyan3", "pyparsing"],
+    install_requires=["numpy", "matplotlib", "Pillow", "pyan3", "pyparsing", "rich"],
     include_package_data=True,
     package_data={"bench_fio": ["templates/*.fio", "scripts/*.sh"]},
     entry_points={


### PR DESCRIPTION
"rich" dependency added toi avoid:
bench-fio
Traceback (most recent call last):
  File "/usr/local/bin/bench-fio", line 5, in <module>
    from bench_fio import main
  File "/usr/local/lib/python3.10/dist-packages/bench_fio/__init__.py", line 14, in <module>
    from .benchlib import (
  File "/usr/local/lib/python3.10/dist-packages/bench_fio/benchlib/checks.py", line 6, in <module>
    from . import runfio
  File "/usr/local/lib/python3.10/dist-packages/bench_fio/benchlib/runfio.py", line 11, in <module>
    from rich.progress import Progress
ModuleNotFoundError: No module named 'rich'