### PR TITLE
fix 134 rbdname crash

### DIFF
--- a/bench_fio/benchlib/checks.py
+++ b/bench_fio/benchlib/checks.py
@@ -53,7 +53,7 @@ def check_target_type(target, settings):
     path_target = Path(target)
 
     if filetype == "rbd":
-        return None
+        return "rbdname"
 
     if not filetype in types:
         print(f"Error, filetype {filetype} is an unknown option.")


### PR DESCRIPTION
Fixed issue 134 from louwrentius master branch
checks.sh check_target_type function returned None which led to failure of bench-fio with TypeError.
Fix was to return rbdname instead of None from check_target_type function.
This correctly sets rbdname in the config dictionary in bench-fio.
The fix tests ok, rbd benchmarking works.