### PR TITLE
Don't apply the implicit runtime always

### DIFF
--- a/bench_fio/__init__.py
+++ b/bench_fio/__init__.py
@@ -22,16 +22,18 @@ from .benchlib import (
     network
 )
 
+
 def gather_settings():
-    settings = defaults.get_default_settings()
+    defaultsettings = defaults.get_default_settings()
     customsettings = parseini.get_settings_from_ini(sys.argv)
-    #print(customsettings)
+    # print(customsettings)
     if not customsettings:
-        args = argparsing.check_args(settings)
+        args = argparsing.check_args(defaultsettings)
         customsettings = vars(args)
-    settings = {**settings, **customsettings}
-    checks.check_settings(settings)
+    settings = {**defaultsettings, **customsettings}
+    checks.check_settings(settings, defaultsettings)
     return settings
+
 
 def main():
     checks.check_encoding()

--- a/bench_fio/benchlib/argparsing.py
+++ b/bench_fio/benchlib/argparsing.py
@@ -90,7 +90,6 @@ def get_arguments(settings):
         help=f"Override the default test runtime per benchmark"
         f"(default: {settings['runtime']})",
         type=int,
-        default=settings["runtime"],
     )
 
     ag.add_argument(

--- a/bench_fio/benchlib/checks.py
+++ b/bench_fio/benchlib/checks.py
@@ -75,7 +75,7 @@ def check_target_type(target, settings):
         return {"file": "filename", "device": "filename", "directory": "directory"}[filetype]
 
 
-def check_settings(settings):
+def check_settings(settings, defaultsettings):
     """Some basic error handling."""
 
     check_fio_version()
@@ -89,6 +89,11 @@ def check_settings(settings):
             print("Preconditioning only makes sense for (flash) devices, not files or directories.")
             print()
             sys.exit(9)
+
+    if not settings["runtime"] and not settings["size"]:
+        # if there is no explicit runtime nor size supplied, fallback to
+        # the default runtime
+        settings["runtime"] = defaultsettings["runtime"]
 
     if settings["type"] not in ["device", "rbd"] and not settings["size"]:
         print()


### PR DESCRIPTION
When `--size` is supplied, it makes sense to complete the testing of the specified size rather than ending the test after the default runtime (60s). However, we should leave a space for a specific use case that an user specifies both `--size` and `--runtime` as per the fio manual.

> runtime=time
>
> The test will run until it completes the configured I/O workload or
> until it has run for this specified amount of time, whichever occurs
> first

Closes: #137