### PR TITLE
Accept a path with a colon

### DIFF
--- a/bench_fio/README.md
+++ b/bench_fio/README.md
@@ -190,7 +190,10 @@ Pure read/write/trim workloads will appear in the *device* folder.
 
 	Generic Settings:
 	-d TARGET [TARGET ...], --target TARGET [TARGET ...]
-							Storage device / directory / file / rbd image (Ceph) to be tested.
+
+							Storage device / directory / file / rbd image (Ceph) to be tested. When the path contains
+							a colon (:), it must be escaped with a backslash (\).
+							Usage example: --target '/dev/disk/by-id/drive-0\:0'
 	-t {device,file,directory,rbd}, --type {device,file,directory,rbd}
 							Target type, device, file, directory or rbd (Ceph)
 	-P CEPH_POOL, --ceph-pool CEPH_POOL
@@ -295,4 +298,3 @@ Bench_fio requires Python3. The 'numpy' python module is required.
 
 You can also use apt/yum to satisfy this requirement.
 
-   

--- a/bench_fio/benchlib/argparsing.py
+++ b/bench_fio/benchlib/argparsing.py
@@ -28,7 +28,12 @@ def get_arguments(settings):
     ag.add_argument(
         "-d",
         "--target",
-        help="Storage device / directory / file / rbd image (Ceph) to be tested.",
+        help=(
+            "Storage device / directory / file / rbd image (Ceph) to be "
+            "tested. When the path contains a colon (:), it must be escaped "
+            "with a backslash (\\). "
+            "Usage example: --target '/dev/disk/by-id/drive-0\\:0'"
+        ),
         required=True,
         nargs="+",
         type=str,

--- a/bench_fio/benchlib/generatefio.py
+++ b/bench_fio/benchlib/generatefio.py
@@ -28,7 +28,7 @@ def filter_options(settings, config, mapping, benchmark, output_directory):
         if isinstance(value, bool):
             value = boolean[str(value)]
         if key == "type":  # we check if we target a file directory or block device
-            devicetype = checks.check_target_type(benchmark["target"], settings)
+            devicetype = checks.check_target_type(benchmark["target_base"], settings)
             config["FIOJOB"][devicetype] = benchmark["target"]
         if (
             value

--- a/bench_fio/benchlib/runfio.py
+++ b/bench_fio/benchlib/runfio.py
@@ -49,7 +49,13 @@ def run_raw_command(command, outputfile=None):
 
 
 def run_fio(settings, benchmark):
-    tmpjobfile = f"/tmp/{os.path.basename(benchmark['target'])}-tmpjobfile.fio"
+    # The target may contains a colon (:) in the path and it's escaped
+    # with a backslash (\) as per the fio manual. The backslash must be
+    # passed to fio's filename but should be removed when checking the
+    # existance of the path, or when writing a job file or log file in
+    # the filesystem.
+    benchmark.update({"target_base": benchmark['target'].replace("\\", "")})
+    tmpjobfile = f"/tmp/{os.path.basename(benchmark['target_base'])}-tmpjobfile.fio"
     output_directory = supporting.generate_output_directory(settings, benchmark)
     output_file = f"{output_directory}/{benchmark['mode']}-{benchmark['iodepth']}-{benchmark['numjobs']}.json"
     generatefio.generate_fio_job_file(settings, benchmark, output_directory, tmpjobfile)

--- a/bench_fio/benchlib/supporting.py
+++ b/bench_fio/benchlib/supporting.py
@@ -42,11 +42,11 @@ def generate_output_directory(settings, benchmark):
     settings["output"] = os.path.expanduser(settings["output"])
     if benchmark["mode"] in settings["mixed"]:
         directory = (
-            f"{settings['output']}/{os.path.basename(benchmark['target'])}/"
+            f"{settings['output']}/{os.path.basename(benchmark['target_base'])}/"
             f"{benchmark['mode']}{benchmark['rwmixread']}/{benchmark['block_size']}"
         )
     else:
-        directory = f"{settings['output']}/{os.path.basename(benchmark['target'])}/{benchmark['block_size']}"
+        directory = f"{settings['output']}/{os.path.basename(benchmark['target_base'])}/{benchmark['block_size']}"
 
     if "run" in benchmark.keys():
         directory = directory + f"/run-{benchmark['run']}"


### PR DESCRIPTION
A colon in filename= in fio has a special meaning and it's used as a delimiter of multiple files. If a path contains a colon, fio expects it's escaped with a backslash. Let's accept a path with a colon in this tool in the same syntax as fio.

Closes: #136