### PR TITLE
Allow forcing a single column layout for the labels

### DIFF
--- a/fio_plot/fiolib/argparsing.py
+++ b/fio_plot/fiolib/argparsing.py
@@ -251,6 +251,14 @@ def set_arguments(settings):
         default=settings["xlabel_segment_size"],
     )
     ag.add_argument(
+        "--xlabel-single-column",
+        help="\
+            Whether to force a single-column layout in the label table \
+                when the number of labels is more than 3.",
+        action="store_true",
+        default=settings["xlabel_single_column"],
+    )
+    ag.add_argument(
         "-w",
         "--line-width",
         help="Line width for line graphs. Can be a floating-point value. Used with -g.",

--- a/fio_plot/fiolib/defaultsettings.py
+++ b/fio_plot/fiolib/defaultsettings.py
@@ -19,6 +19,7 @@ def get_default_settings():
     settings["xlabel_depth"] = 0
     settings["xlabel_parent"] = 1
     settings["xlabel_segment_size"] = 1000
+    settings["xlabel_single_column"] = False
     settings["line_width"] = 1
     settings["group_bars"] = False
     settings["show_cpu"] = False

--- a/fio_plot/fiolib/graph2dsupporting.py
+++ b/fio_plot/fiolib/graph2dsupporting.py
@@ -224,7 +224,7 @@ def generate_labelset(settings, supportdata):
     values.insert(0, header)
 
     ncol = 1
-    if len(values) > 3:
+    if len(values) > 3 and not settings["xlabel_single_column"]:
         ncol = 2
         number = len(values)
         position = int(number / 2) + 1


### PR DESCRIPTION
When the number of labels is more than 3, the tables are created with two columns. The new option allows forcing a single column. I think it depends on preferences so I made it as a config option.

[w/o the option]
![two_columns](https://github.com/louwrentius/fio-plot/assets/4356209/44b7a747-cc43-4518-bd37-93ed9e2cee10)

[w/ the option]
![single_column](https://github.com/louwrentius/fio-plot/assets/4356209/070dec9a-bbad-4f1c-bc4d-4e765d255120)

Also, extend the table to include median.

[before]
![image](https://github.com/louwrentius/fio-plot/assets/4356209/abea4dc7-3553-4ca9-a456-f5b786394cdb)

[after]
![Screenshot from 2024-02-07 00-08-31](https://github.com/louwrentius/fio-plot/assets/4356209/2bda6212-3475-46a5-9184-03f19f255e70)