### PR TITLE
Fixing same data added twice when scaling bandwidth logs

### DIFF
--- a/fio_plot/fiolib/supporting.py
+++ b/fio_plot/fiolib/supporting.py
@@ -542,26 +542,3 @@ def filter_hosts(settings, item):
     else:
         outcome = True
     return outcome
-
-def get_vlines(vlines_location):
-    vlines = []
-    if not os.path.isfile(vlines_location):
-        return vlines
-    with open(vlines_location, 'r', encoding='UTF-8') as file:
-        while line := file.readline():
-            if (line.rstrip()):
-                vlines.append(int(line.rstrip()))
-    
-    return vlines
-
-def get_vspans(vspan_location):
-    vspan = []
-    if not os.path.isfile(vspan_location):
-        return vspan
-    with open(vspan_location, 'r', encoding='UTF-8') as file:
-        while line := file.readline():
-            if (line.rstrip()):
-                xcoord1 = line.rstrip().split(" ")[0]
-                xcoord2 = line.rstrip().split(" ")[1]
-                vspan.append((int(xcoord1), int(xcoord2)))
-    return vspan

--- a/fio_plot/fiolib/supporting.py
+++ b/fio_plot/fiolib/supporting.py
@@ -272,7 +272,7 @@ def process_dataset(settings, dataset):
                                 get_scale_factor_bw(record["total"]["yvalues"])
                             )
                     # print(item["hostname"])
-                    new_list.append(record)
+            new_list.append(record)
     item.pop("data")
 
     """
@@ -542,3 +542,26 @@ def filter_hosts(settings, item):
     else:
         outcome = True
     return outcome
+
+def get_vlines(vlines_location):
+    vlines = []
+    if not os.path.isfile(vlines_location):
+        return vlines
+    with open(vlines_location, 'r', encoding='UTF-8') as file:
+        while line := file.readline():
+            if (line.rstrip()):
+                vlines.append(int(line.rstrip()))
+    
+    return vlines
+
+def get_vspans(vspan_location):
+    vspan = []
+    if not os.path.isfile(vspan_location):
+        return vspan
+    with open(vspan_location, 'r', encoding='UTF-8') as file:
+        while line := file.readline():
+            if (line.rstrip()):
+                xcoord1 = line.rstrip().split(" ")[0]
+                xcoord2 = line.rstrip().split(" ")[1]
+                vspan.append((int(xcoord1), int(xcoord2)))
+    return vspan


### PR DESCRIPTION
Hi,
I discovered an issue with y-axis units and the legends in line plot for bandwidth logs.
There is a misplaced append happening in the for loop where values are scaled.
The same dictionary gets pushed in the list twice for each op type (essentially twice for read and write).

Fixed it by moving the append to the correct level in the loop.