### PR TITLE
docs: fix README dependencies heading

### DIFF
--- a/README.md
+++ b/README.md
@@ -252,7 +252,7 @@ For more examples, please consult the separate [README.md][rm]
 
 [rm]: https://github.com/louwrentius/fio-plot/tree/master/bench_fio#readme
 
-## Dependancies
+## Dependencies
 
 Fio-plot requires 'matplotlib' and 'numpy' to be installed.
 


### PR DESCRIPTION
## Summary

Fix the README section heading from `Dependancies` to `Dependencies`.

## Validation

- `rg -n "Dependancies|Dependencies" README.md`
- `git diff --check`

No code or generated files changed.